### PR TITLE
Find Sims Install

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET
 
 env:
   PACK_ID: Sims1WidescreenPatcher
-  PACK_VER: 3.5.0
+  PACK_VER: 3.6.0
 
 on: 
   push:

--- a/Sims1WidescreenPatcher.Core/Services/IFindSimsPathService.cs
+++ b/Sims1WidescreenPatcher.Core/Services/IFindSimsPathService.cs
@@ -1,0 +1,7 @@
+﻿namespace Sims1WidescreenPatcher.Core.Services
+{
+    public interface IFindSimsPathService
+    {
+        string FindSimsPath();
+    }
+}

--- a/Sims1WidescreenPatcher.Core/ViewModels/MainWindowViewModel.cs
+++ b/Sims1WidescreenPatcher.Core/ViewModels/MainWindowViewModel.cs
@@ -28,6 +28,7 @@ public class MainWindowViewModel : ViewModelBase
     private readonly List<string> _previouslyPatched = new();
     private readonly IProgressService _progressService;
     private readonly ObservableAsPropertyHelper<double> _progress;
+    private readonly IFindSimsPathService _findSimsPathService;
 
     #endregion
 
@@ -36,7 +37,8 @@ public class MainWindowViewModel : ViewModelBase
     public MainWindowViewModel(IResolutionsService resolutionsService,
         CustomYesNoDialogViewModel customYesNoDialogViewModel,
         CustomResolutionDialogViewModel customResolutionDialogViewModel,
-        IProgressService progressService)
+        IProgressService progressService,
+        IFindSimsPathService findSimsPathService)
     {
         _progressService = progressService;
         _customYesNoDialogViewModel = customYesNoDialogViewModel;
@@ -76,6 +78,8 @@ public class MainWindowViewModel : ViewModelBase
         CustomResolutionCommand = ReactiveCommand.CreateFromTask(OpenCustomResolutionDialogAsync);
         ShowCustomYesNoDialog = new Interaction<CustomYesNoDialogViewModel, YesNoDialogResponse?>();
         ShowCustomInformationDialog = new Interaction<CustomInformationDialogViewModel, Unit>();
+        _findSimsPathService = findSimsPathService;
+        Path = _findSimsPathService.FindSimsPath();
 
         var progressPct = Observable.FromEventPattern<NewProgressEventArgs>(_progressService, "NewProgressEventHandler");
         progressPct

--- a/Sims1WidescreenPatcher.Linux/Services/FindSimsPathService.cs
+++ b/Sims1WidescreenPatcher.Linux/Services/FindSimsPathService.cs
@@ -1,0 +1,11 @@
+using Sims1WidescreenPatcher.Core.Services;
+
+namespace Sims1WidescreenPatcher.Linux.Services;
+
+public class FindSimsPathService : IFindSimsPathService
+{
+    public string FindSimsPath()
+    {
+        return string.Empty;
+    }
+}

--- a/Sims1WidescreenPatcher.Linux/Services/FindSimsPathService.cs
+++ b/Sims1WidescreenPatcher.Linux/Services/FindSimsPathService.cs
@@ -4,8 +4,5 @@ namespace Sims1WidescreenPatcher.Linux.Services;
 
 public class FindSimsPathService : IFindSimsPathService
 {
-    public string FindSimsPath()
-    {
-        return string.Empty;
-    }
+    public string FindSimsPath() => string.Empty;
 }

--- a/Sims1WidescreenPatcher.Linux/Sims1WidescreenPatcher.Linux.csproj
+++ b/Sims1WidescreenPatcher.Linux/Sims1WidescreenPatcher.Linux.csproj
@@ -12,6 +12,7 @@
 		<FileVersion>3.3.0</FileVersion>
 		<InformationalVersion>3.3.0</InformationalVersion>
 		<ApplicationIcon>..\Sims1WidescreenPatcher.UI\Assets\SimsICO.ico</ApplicationIcon>
+		<LangVersion>default</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<AvaloniaResource Include="Assets\**" />

--- a/Sims1WidescreenPatcher.MacOS/Services/FindSimsPathService.cs
+++ b/Sims1WidescreenPatcher.MacOS/Services/FindSimsPathService.cs
@@ -1,0 +1,8 @@
+using Sims1WidescreenPatcher.Core.Services;
+
+namespace Sims1WidescreenPatcher.MacOS.Services;
+
+public class FindSimsPathService : IFindSimsPathService
+{
+    public string FindSimsPath() => string.Empty;
+}

--- a/Sims1WidescreenPatcher.MacOS/Sims1WidescreenPatcher.MacOS.csproj
+++ b/Sims1WidescreenPatcher.MacOS/Sims1WidescreenPatcher.MacOS.csproj
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<OutputType>Library</OutputType>
 		<TargetFramework>netstandard2.0</TargetFramework>
+		<LangVersion>default</LangVersion>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/Sims1WidescreenPatcher.Windows/Services/FindSimsPathService.cs
+++ b/Sims1WidescreenPatcher.Windows/Services/FindSimsPathService.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.IO;
+using Microsoft.Win32;
+using Sims1WidescreenPatcher.Core.Services;
+
+namespace Sims1WidescreenPatcher.Windows.Services;
+
+public class FindSimsPathService : IFindSimsPathService
+{
+    public string FindSimsPath()
+    {
+        try
+        {
+            using var key = Registry.LocalMachine.OpenSubKey(@"SOFTWARE\WOW6432Node\Maxis\The Sims");
+            var val = key.GetValue("InstallPath").ToString();
+            var path = Path.Combine(val, "Sims.exe");
+            return path;
+        }
+        catch (Exception)
+        {
+            return string.Empty;
+        }
+    }
+}

--- a/Sims1WidescreenPatcher.Windows/Sims1WidescreenPatcher.Windows.csproj
+++ b/Sims1WidescreenPatcher.Windows/Sims1WidescreenPatcher.Windows.csproj
@@ -12,6 +12,7 @@
 		<Product>Sims1WidescreenPatcher</Product>
 		<IsPackable>false</IsPackable>
 		<ApplicationIcon>..\Sims1WidescreenPatcher.UI\Assets\SimsICO.ico</ApplicationIcon>
+		<LangVersion>default</LangVersion>
 	</PropertyGroup>
 	<ItemGroup>
 		<AvaloniaResource Include="Assets\**" />
@@ -25,6 +26,7 @@
 		<TrimmableAssembly Include="Avalonia.Themes.Default" />
 	</ItemGroup>
 	<ItemGroup>
+		<PackageReference Include="Microsoft.Windows.Compatibility" Version="7.0.4" />
 		<PackageReference Include="Serilog.Formatting.Compact" Version="1.1.0" />
 		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
 		<!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->

--- a/Sims1WidescreenPatcher/DependencyInjection/ServicesBootstrapper.cs
+++ b/Sims1WidescreenPatcher/DependencyInjection/ServicesBootstrapper.cs
@@ -23,6 +23,7 @@ namespace Sims1WidescreenPatcher.DependencyInjection
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 services.RegisterLazySingleton<IResolutionsService>(() => new WindowsResolutionsService());
+                services.Register<IFindSimsPathService>(() => new FindSimsPathService());
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {

--- a/Sims1WidescreenPatcher/DependencyInjection/ServicesBootstrapper.cs
+++ b/Sims1WidescreenPatcher/DependencyInjection/ServicesBootstrapper.cs
@@ -1,12 +1,11 @@
-﻿using Sims1WidescreenPatcher.Core.Models;
-using Sims1WidescreenPatcher.Core.Services;
+﻿using Sims1WidescreenPatcher.Core.Services;
 using Sims1WidescreenPatcher.Linux.Services;
 using Sims1WidescreenPatcher.MacOS.Services;
-using Sims1WidescreenPatcher.Utilities.Models;
 using Sims1WidescreenPatcher.Utilities.Services;
 using Sims1WidescreenPatcher.Windows.Services;
 using Splat;
 using System.Runtime.InteropServices;
+using FindSimsPathService = Sims1WidescreenPatcher.Windows.Services.FindSimsPathService;
 
 namespace Sims1WidescreenPatcher.DependencyInjection
 {
@@ -32,6 +31,7 @@ namespace Sims1WidescreenPatcher.DependencyInjection
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {
                 services.RegisterLazySingleton<IResolutionsService>(() => new LinuxResolutionService());
+                services.Register<IFindSimsPathService>(() => new Linux.Services.FindSimsPathService());
             }
             else
             {

--- a/Sims1WidescreenPatcher/DependencyInjection/ServicesBootstrapper.cs
+++ b/Sims1WidescreenPatcher/DependencyInjection/ServicesBootstrapper.cs
@@ -27,6 +27,7 @@ namespace Sims1WidescreenPatcher.DependencyInjection
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 services.RegisterLazySingleton<IResolutionsService>(() => new MacOsResolutionService());
+                services.Register<IFindSimsPathService>(() => new MacOS.Services.FindSimsPathService());
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {

--- a/Sims1WidescreenPatcher/DependencyInjection/ViewModelBootstrapper.cs
+++ b/Sims1WidescreenPatcher/DependencyInjection/ViewModelBootstrapper.cs
@@ -15,7 +15,8 @@ namespace Sims1WidescreenPatcher.DependencyInjection
                 resolver.GetService<IResolutionsService>()!,
                 resolver.GetService<CustomYesNoDialogViewModel>()!,
                 resolver.GetService<CustomResolutionDialogViewModel>()!,
-                resolver.GetService<IProgressService>()!));
+                resolver.GetService<IProgressService>()!,
+                resolver.GetService<IFindSimsPathService>()!));
         }
     }
 }


### PR DESCRIPTION
This PR adds the FindSimsInstall service which will try to automatically detect where sims is installed by reading the registry on Windows. No attempt is made to find a Sims install on Linux and macOS.