### PR TITLE
Fix #77

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -2,7 +2,7 @@ name: .NET
 
 env:
   PACK_ID: Sims1WidescreenPatcher
-  PACK_VER: 3.7.1
+  PACK_VER: 3.7.2
 
 on: 
   push:

--- a/Sims1WidescreenPatcher.Utilities/PatchUtility.cs
+++ b/Sims1WidescreenPatcher.Utilities/PatchUtility.cs
@@ -9,7 +9,7 @@ public static class PatchUtility
 
     public static bool IsValidSims(string path)
     {
-        if (string.IsNullOrWhiteSpace(path)) return false;
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return false;
         Log.Information("Begin check Sims executable is valid");
         var pattern = Pattern.Transform(BytePattern);
         var bytes = File.ReadAllBytes(path);
@@ -53,7 +53,7 @@ public static class PatchUtility
 
     public static bool SimsBackupExists(string path)
     {
-        if (string.IsNullOrWhiteSpace(path)) return false;
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return false;
         Log.Information("Begin check backup exists for Sims executable");
         Log.Debug("Path {Path}", path);
         var fileName = Path.GetFileNameWithoutExtension(path);
@@ -67,7 +67,7 @@ public static class PatchUtility
 
     private static void BackupSims(string path)
     {
-        if (string.IsNullOrWhiteSpace(path)) return;
+        if (string.IsNullOrWhiteSpace(path) || !File.Exists(path)) return;
         Log.Information("Begin backup of Sims executable");
         var fileName = Path.GetFileNameWithoutExtension(path);
         var dir = Path.GetDirectoryName(path) ?? string.Empty;

--- a/Sims1WidescreenPatcher.Windows/Services/FindSimsPathService.cs
+++ b/Sims1WidescreenPatcher.Windows/Services/FindSimsPathService.cs
@@ -15,7 +15,7 @@ public class FindSimsPathService : IFindSimsPathService
             var val = key?.GetValue("InstallPath")?.ToString();
             if (string.IsNullOrWhiteSpace(val)) return string.Empty;
             var path = Path.Combine(val, "Sims.exe");
-            return path;
+            return File.Exists(path) ? path : string.Empty;
         }
         catch (Exception)
         {


### PR DESCRIPTION
3.6.0 introduced a bad state that wouldn't have happened prior. The registry key that contains the path to the Sims install may not be correct and return a bogus path. This would cause the patcher to try to read the bytes of an exe that didn't exist. This is part of the process to detect whether or not it could patch it and caused the program to not open for some users.

This PR fixes this issue by checking if the path from the registry key exists before returning it. If it does exist, return the path, if not, return an empty string. I also added more file exist checks to the patch process.